### PR TITLE
untested fix: RSS ingester runs in a hot loop

### DIFF
--- a/packages/repco-core/src/datasource.ts
+++ b/packages/repco-core/src/datasource.ts
@@ -518,7 +518,7 @@ export async function ingestUpdatesFromDataSource(
       `ingest ${uid}: ${records.length} records, ${entities.length} entities, ${errors.length} errors`,
     )
 
-    const finished = records.length === 0
+    const finished = records.length === 0 || nextCursor == cursor
     if (errors) {
       for (const error of errors) {
         log.warn({


### PR DESCRIPTION
The RSS ingester claims to find new records for each call to `fetchUpdate` for most feeds. This is a serious bug, as this creates new source records in a loop. Instead it should return no records and the same cursor as before if no newer items are in the feed. This would make the ingester wait for 10s and then re-poll.

This is an attempt at a fix. Not tested much - this will need manual testing in a test setup and confirm that it works with new items being added to the feed etc.